### PR TITLE
added support for running demos on CPU when no CUDA devices are found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+
+images/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# PyTorch weights
+*.tar
+*.pth
+*.gz
+Untitled.ipynb
+Testing notebook.ipynb

--- a/image_demo.py
+++ b/image_demo.py
@@ -18,7 +18,8 @@ args = parser.parse_args()
 
 def main():
     model = posenet.load_model(args.model)
-    model = model.cuda()
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = model.to(device=device)
     output_stride = model.output_stride
 
     if args.output_dir:
@@ -34,7 +35,7 @@ def main():
             f, scale_factor=args.scale_factor, output_stride=output_stride)
 
         with torch.no_grad():
-            input_image = torch.Tensor(input_image).cuda()
+            input_image = torch.Tensor(input_image).to(device=device)
 
             heatmaps_result, offsets_result, displacement_fwd_result, displacement_bwd_result = model(input_image)
 

--- a/webcam_demo.py
+++ b/webcam_demo.py
@@ -16,7 +16,8 @@ args = parser.parse_args()
 
 def main():
     model = posenet.load_model(args.model)
-    model = model.cuda()
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = model.to(device=device)
     output_stride = model.output_stride
 
     cap = cv2.VideoCapture(args.cam_id)
@@ -30,7 +31,7 @@ def main():
             cap, scale_factor=args.scale_factor, output_stride=output_stride)
 
         with torch.no_grad():
-            input_image = torch.Tensor(input_image).cuda()
+            input_image = torch.Tensor(input_image).to(device=device)
 
             heatmaps_result, offsets_result, displacement_fwd_result, displacement_bwd_result = model(input_image)
 


### PR DESCRIPTION
The current demo implementation gives an `AssertionError` when no NVidia driver is found. I replaced `.cuda()` with `.to(device=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))` so that the image and webcam demos can be run on CPU when no CUDA device is found.